### PR TITLE
Redis connection fix

### DIFF
--- a/config/event_tracker.php
+++ b/config/event_tracker.php
@@ -29,14 +29,13 @@ return [
         ],
         'prometheus' => [
             'redis' => [
-                'client' => 'phpredis',
-                'default' => [
-                    'url' => 'localhost',
-                    'host' => 'localhost',
-                    'username' => 'redis',
-                    'password' => '',
-                    'port' => '6379',
-                    'database' => 0,
+                'client' => env('EVENT_TRACKER_REDIS_CLIENT', 'phpredis'),
+                'connection' => [
+                    'host' => env('EVENT_TRACKER_REDIS_HOST', 'localhost'),
+                    'username' => env('EVENT_TRACKER_REDIS_USERNAME', 'redis'),
+                    'password' => env('EVENT_TRACKER_REDIS_PASSWORD'),
+                    'port' => env('EVENT_TRACKER_REDIS_PORT', '6379'),
+                    'database' => env('EVENT_TRACKER_REDIS_DATABASE', 0),
                 ]
             ],
             'labels' => [

--- a/config/event_tracker.php
+++ b/config/event_tracker.php
@@ -30,7 +30,7 @@ return [
         'prometheus' => [
             'redis' => [
                 'client' => env('EVENT_TRACKER_REDIS_CLIENT', 'phpredis'),
-                'connection' => [
+                'credentials' => [
                     'host' => env('EVENT_TRACKER_REDIS_HOST', 'localhost'),
                     'username' => env('EVENT_TRACKER_REDIS_USERNAME', 'redis'),
                     'password' => env('EVENT_TRACKER_REDIS_PASSWORD'),

--- a/config/event_tracker.php
+++ b/config/event_tracker.php
@@ -28,7 +28,17 @@ return [
             ],
         ],
         'prometheus' => [
-            'redis' => 'default',
+            'redis' => [
+                'client' => 'phpredis',
+                'default' => [
+                    'url' => 'localhost',
+                    'host' => 'localhost',
+                    'username' => 'redis',
+                    'password' => '',
+                    'port' => '6379',
+                    'database' => 0,
+                ]
+            ],
             'labels' => [
                 'namespace' => 'app_ns',
             ],

--- a/config/event_tracker.php
+++ b/config/event_tracker.php
@@ -36,7 +36,7 @@ return [
                     'password' => env('EVENT_TRACKER_REDIS_PASSWORD'),
                     'port' => env('EVENT_TRACKER_REDIS_PORT', '6379'),
                     'database' => env('EVENT_TRACKER_REDIS_DATABASE', 0),
-                ]
+                ],
             ],
             'labels' => [
                 'namespace' => 'app_ns',

--- a/src/Repositories/PrometheusRepository/Installer.php
+++ b/src/Repositories/PrometheusRepository/Installer.php
@@ -28,7 +28,7 @@ class Installer extends BaseRepositoryInstaller
                 'driver' => $redisConfig['client'],
                 'config' => $redisConfig,
             ]);
-            $redis = $redisManager->connection('connection')
+            $redis = $redisManager->connection('credentials')
                 ->client();
             $redis->setOption(NativeRedis::OPT_PREFIX, '');
 

--- a/src/Repositories/PrometheusRepository/Installer.php
+++ b/src/Repositories/PrometheusRepository/Installer.php
@@ -23,8 +23,13 @@ class Installer extends BaseRepositoryInstaller
 
         $this->app->singleton(PrometheusRepositoryContract::class, function () use ($config) {
             $redisConfig = $config['connections']['prometheus']['redis'];
-            $redisManager = $this->app->make(RedisManager::class, ['app' => $this->app, 'driver' => $redisConfig['client'], 'config' => $redisConfig]);
-            $redis = $redisManager->connection('connection')->client();
+            $redisManager = $this->app->make(RedisManager::class, [
+                'app' => $this->app,
+                'driver' => $redisConfig['client'],
+                'config' => $redisConfig,
+            ]);
+            $redis = $redisManager->connection('connection')
+                ->client();
             $redis->setOption(NativeRedis::OPT_PREFIX, '');
 
             $storage = Redis::fromExistingConnection($redis);

--- a/src/Repositories/PrometheusRepository/Installer.php
+++ b/src/Repositories/PrometheusRepository/Installer.php
@@ -23,7 +23,7 @@ class Installer extends BaseRepositoryInstaller
 
         $this->app->singleton(PrometheusRepositoryContract::class, function () use ($config) {
             $redisConfig = $config['connections']['prometheus']['redis'];
-            $redisManager = $this->app->make(RedisManager::class, [$this->app, $redisConfig['client'], $redisConfig]);
+            $redisManager = $this->app->make(RedisManager::class, ['app' => $this->app, 'driver' => $redisConfig['client'], 'config' => $redisConfig]);
             $redis = $redisManager->connection('connection')->client();
             $redis->setOption(NativeRedis::OPT_PREFIX, '');
 

--- a/src/Repositories/PrometheusRepository/Installer.php
+++ b/src/Repositories/PrometheusRepository/Installer.php
@@ -23,8 +23,8 @@ class Installer extends BaseRepositoryInstaller
 
         $this->app->singleton(PrometheusRepositoryContract::class, function () use ($config) {
             $redisConfig = $config['connections']['prometheus']['redis'];
-            $redisManager = new RedisManager($this->app, $redisConfig['client'], $redisConfig);
-            $redis = $redisManager->connection('default')->client();
+            $redisManager = $this->app->make(RedisManager::class, [$this->app, $redisConfig['client'], $redisConfig]);
+            $redis = $redisManager->connection('connection')->client();
             $redis->setOption(NativeRedis::OPT_PREFIX, '');
 
             $storage = Redis::fromExistingConnection($redis);

--- a/src/Repositories/PrometheusRepository/Installer.php
+++ b/src/Repositories/PrometheusRepository/Installer.php
@@ -22,11 +22,9 @@ class Installer extends BaseRepositoryInstaller
         }
 
         $this->app->singleton(PrometheusRepositoryContract::class, function () use ($config) {
-            /** @var RedisManager $redisManager */
-            $redisManager = $this->app->make(RedisManager::class);
-            $connection = $config['connections']['prometheus']['redis'];
-            $redis = $redisManager->connection($connection)
-                ->client();
+            $redisConfig = $config['connections']['prometheus']['redis'];
+            $redisManager = new RedisManager($this->app, $redisConfig['client'], $redisConfig);
+            $redis = $redisManager->connection('default')->client();
             $redis->setOption(NativeRedis::OPT_PREFIX, '');
 
             $storage = Redis::fromExistingConnection($redis);

--- a/src/Repositories/PrometheusRepository/Installer.php
+++ b/src/Repositories/PrometheusRepository/Installer.php
@@ -23,11 +23,7 @@ class Installer extends BaseRepositoryInstaller
 
         $this->app->singleton(PrometheusRepositoryContract::class, function () use ($config) {
             $redisConfig = $config['connections']['prometheus']['redis'];
-            $redisManager = $this->app->make(RedisManager::class, [
-                'app' => $this->app,
-                'driver' => $redisConfig['client'],
-                'config' => $redisConfig,
-            ]);
+            $redisManager = new RedisManager($this->app, $redisConfig['client'], $redisConfig);
             $redis = $redisManager->connection('credentials')
                 ->client();
             $redis->setOption(NativeRedis::OPT_PREFIX, '');


### PR DESCRIPTION
Laravel doesnt have ability to use different redis-clients for different connections. It can be problem if you want to use sentinel-connection for app and phpredis for metrics.

So, in the PR i changed redis config for Prometheus. Now, you can specify redis-client and all credentials right in event-tracker.php config